### PR TITLE
修复自动下载，改进代码风格

### DIFF
--- a/platform/component/auto_dl/auto_dl.c
+++ b/platform/component/auto_dl/auto_dl.c
@@ -27,20 +27,23 @@ void Reset_to_ROM()
     ((void (*)())(rv))(); // go to ROM
 }
 
-__attribute__((weak)) void USER_UART0_RX(void)
+__attribute__((weak)) void USER_UART0_RX(uint8_t ch)
 {
     UNUSED(UART0);
+    UNUSED(ch);
 }
 
 void Auto_DL_Handler()
 {
+    uint8_t ch;
     if(UART0->FIFOS & 0xFC0){
         if(last > HAL_GetTick() + timeout){
             p = atz; // timeout
         }
         last = HAL_GetTick();
         do{
-            if(*p++ == (uint8_t)UART0->RDW){
+            ch = (uint8_t)UART0->RDW;
+            if(*p++ == ch){
                 if(p == &atz[6]){
                     Reset_to_ROM();
                     p = atz;  // reset faild
@@ -48,7 +51,7 @@ void Auto_DL_Handler()
             }else{
                 p = atz;  // not match
             }
-            USER_UART0_RX();
+            USER_UART0_RX(ch);
         }while(UART0->FIFOS & 0xFC0);
     }
 }

--- a/platform/component/auto_dl/auto_dl.c
+++ b/platform/component/auto_dl/auto_dl.c
@@ -44,6 +44,7 @@ void Auto_DL_Handler()
         }
         last = HAL_GetTick();
         do{
+            SET_BIT(UART0->INTS, UART_INTS_RL); // clear interrupt flag
             ch = (uint8_t)READ_REG(UART0->RDW);
             if(*p++ == ch){
                 if(p >= atz + strlen(atz)){
@@ -55,7 +56,6 @@ void Auto_DL_Handler()
             }
             USER_UART0_RX(ch);
         }while(RX_COUNT);
-        SET_BIT(UART0->INTS, UART_INTS_RL); // clear interrupt flag
     }
 }
 

--- a/platform/component/auto_dl/auto_dl.c
+++ b/platform/component/auto_dl/auto_dl.c
@@ -33,10 +33,12 @@ __attribute__((weak)) void USER_UART0_RX(uint8_t ch)
     UNUSED(ch);
 }
 
+#define RX_COUNT ((UART0->FIFOS & UART_FIFOS_RFC_Msk) >> UART_FIFOS_RFC_Pos)
+
 void Auto_DL_Handler()
 {
     uint8_t ch;
-    if(UART0->FIFOS & 0xFC0){
+    if(RX_COUNT){
         if(last > HAL_GetTick() + timeout){
             p = atz; // timeout
         }
@@ -44,7 +46,7 @@ void Auto_DL_Handler()
         do{
             ch = (uint8_t)UART0->RDW;
             if(*p++ == ch){
-                if(p == &atz[6]){
+                if(p >= atz + strlen(atz)){
                     Reset_to_ROM();
                     p = atz;  // reset faild
                 }
@@ -52,7 +54,7 @@ void Auto_DL_Handler()
                 p = atz;  // not match
             }
             USER_UART0_RX(ch);
-        }while(UART0->FIFOS & 0xFC0);
+        }while(RX_COUNT);
         UART0->INTS = UART_INTS_RL;
     }
 }

--- a/platform/component/auto_dl/auto_dl.c
+++ b/platform/component/auto_dl/auto_dl.c
@@ -53,6 +53,7 @@ void Auto_DL_Handler()
             }
             USER_UART0_RX(ch);
         }while(UART0->FIFOS & 0xFC0);
+        UART0->INTS = UART_INTS_RL;
     }
 }
 

--- a/platform/component/auto_dl/auto_dl.c
+++ b/platform/component/auto_dl/auto_dl.c
@@ -22,7 +22,7 @@ uint32_t last = 0;
 
 void Reset_to_ROM()
 {
-    RCC->RST = 0;  // reset all peripheral
+    CLEAR_REG(RCC->RST);  // reset all peripheral
     uint32_t rv = *(uint32_t*)(0x00000000U); // get reset vector
     ((void (*)())(rv))(); // go to ROM
 }
@@ -44,7 +44,7 @@ void Auto_DL_Handler()
         }
         last = HAL_GetTick();
         do{
-            ch = (uint8_t)UART0->RDW;
+            ch = (uint8_t)READ_REG(UART0->RDW);
             if(*p++ == ch){
                 if(p >= atz + strlen(atz)){
                     Reset_to_ROM();
@@ -55,7 +55,7 @@ void Auto_DL_Handler()
             }
             USER_UART0_RX(ch);
         }while(RX_COUNT);
-        UART0->INTS = UART_INTS_RL;
+        SET_BIT(UART0->INTS, UART_INTS_RL); // clear interrupt flag
     }
 }
 


### PR DESCRIPTION
接收到的字节作为USER_UART0_RX(ch)的参数，用户可获得串口接收内容。
发送任意字符后卡住，清除接收中断标志后，问题已解决。
重构部分代码，避免使用魔数。用宏RX_COUNT获取rxfifo数据个数，用strlen获取字符串长度。