### PR TITLE
small fixes to run with generic gcc/binutils and BSD environment

### DIFF
--- a/tools/W806/conf.mk
+++ b/tools/W806/conf.mk
@@ -53,13 +53,19 @@ ifeq ($(CONFIG_W800_FIRMWARE_DEBUG),y)
 optimization += -g -DWM_SWD_ENABLE=1
 endif
 
+cputype = ck804ef
+
 # YES; NO
 VERBOSE ?= NO
 
-UNAME_O:=$(shell uname -o)
-UNAME_S:=$(shell uname -s)
+UNAME:=$(shell uname)
+ifneq (,$(findstring MINGW,$(UNAME)))
+    UNAME=Msys
+else ifneq (,$(findstring MSYS_NT,$(UNAME)))
+    UNAME=Msys
+endif
 
-$(shell gcc $(SDK_TOOLS)/wm_getver.c -Wall -O2 -o $(VER_TOOL))
+$(shell cc $(SDK_TOOLS)/wm_getver.c -Wall -O2 -o $(VER_TOOL))
 
 TOOL_CHAIN_PREFIX = $(CONFIG_W800_TOOLCHAIN_PREFIX)
 TOOL_CHAIN_PATH = $(subst ",,$(CONFIG_W800_TOOLCHAIN_PATH))
@@ -91,7 +97,7 @@ LIB_EXT = .a
 CCFLAGS := -Wall \
     -DTLS_CONFIG_CPU_XT804=1 \
     -DGCC_COMPILE=1 \
-    -mcpu=ck804ef \
+    -mcpu=$(cputype) \
     $(optimization) \
     -std=gnu99 \
     -c  \
@@ -103,7 +109,7 @@ CCFLAGS := -Wall \
 CCXXFLAGS := -Wall \
     -DTLS_CONFIG_CPU_XT804=1 \
     -DGCC_COMPILE=1 \
-    -mcpu=ck804ef \
+    -mcpu=$(cputype) \
     $(optimization) \
     -std=gnu++11 \
     -c  \
@@ -115,7 +121,7 @@ CCXXFLAGS := -Wall \
 ASMFLAGS := -Wall \
     -DTLS_CONFIG_CPU_XT804=1 \
     -DGCC_COMPILE=1 \
-    -mcpu=ck804ef \
+    -mcpu=$(cputype) \
     $(optimization) \
     -std=gnu99 \
     -c  \
@@ -128,7 +134,7 @@ ARFLAGS := ru
 
 ARFLAGS_2 = xo
 
-LINKFLAGS := -mcpu=ck804ef \
+LINKFLAGS := -mcpu=$(cputype) \
     -nostartfiles \
     -mhard-float \
     -lm \

--- a/tools/W806/mconfig.sh
+++ b/tools/W806/mconfig.sh
@@ -1,4 +1,9 @@
+MAKE=$1
+if [ -z ${MAKE} ]; then
+    MAKE=make
+fi
+
 cd tools/W806/config
-make mconf
+${MAKE} mconf
 cd ..
 ../../bin/build/config/mconf wconfig

--- a/tools/W806/rules.mk
+++ b/tools/W806/rules.mk
@@ -64,18 +64,16 @@ $(BINODIR)/%.bin: $(IMAGEODIR)/%.elf
 	@mkdir -p $(FIRMWAREDIR)/$(TARGET)
 	$(OBJCOPY) -O binary $(IMAGEODIR)/$(TARGET).elf $(FIRMWAREDIR)/$(TARGET)/$(TARGET).bin
 
-ifeq ($(UNAME_S),Linux)
+ifeq ($(UNAME),Linux)
 	@gcc $(SDK_TOOLS)/wm_tool.c -lpthread -o $(WM_TOOL)
-else
-ifeq ($(UNAME_O),Darwin)
+else ifeq ($(UNAME),OpenBSD)
+	@cc $(SDK_TOOLS)/wm_tool.c -lpthread -o $(WM_TOOL)
+else ifeq ($(UNAME),Darwin)
 	@gcc $(SDK_TOOLS)/wm_tool.c -lpthread -o $(WM_TOOL)
-else
-ifeq ($(UNAME_O),Msys)
+else ifeq ($(UNAME),Msys)
 	@gcc $(SDK_TOOLS)/wm_tool.c -lpthread -o $(WM_TOOL)
 else
 # windows, cygwin-gcc exist bug for uart rts/cts
-endif
-endif
 endif
 
 ifeq ($(CODE_ENCRYPT),1)
@@ -140,7 +138,7 @@ lib: .subdirs $(OBJS) $(OLIBS)
 	@echo "libs has been updated."
 
 menuconfig:
-	@$(SDK_TOOLS)/mconfig.sh
+	@$(SDK_TOOLS)/mconfig.sh $(MAKE)
 
 clean:
 #	$(foreach d, $(SUBDIRS), $(MAKE) -C $(d) clean;)


### PR DESCRIPTION
I want to run wm-sdk-w806 on OpenBSD.
Different from Linux, we do not have any compilier binary package so need to build gcc/binutils/newlib tar ball.
I use binutils-2.34, gcc-9.4.0 and newlib-4.1.0 and make some modification to this SDK.

The goal is make a small hook for skilled-user who want to use generic (not customized for W806) toolchain or non-Linux user.

Currently menuconfig is not working and -ckmap option of ld is kept.
