### PR TITLE
add OpenBSD support

### DIFF
--- a/tools/W806/conf.mk
+++ b/tools/W806/conf.mk
@@ -115,7 +115,6 @@ CCFLAGS := -Wall \
     -std=gnu99 \
     -c  \
     -mhard-float  \
-    -Wall  \
     $(extra_flag)  \
     -fdata-sections  \
     -ffunction-sections
@@ -128,7 +127,6 @@ CCXXFLAGS := -Wall \
     -std=gnu++11 \
     -c  \
     -mhard-float  \
-    -Wall  \
     $(extra_flag)  \
     -fdata-sections  \
     -ffunction-sections

--- a/tools/W806/config/Makefile
+++ b/tools/W806/config/Makefile
@@ -1,14 +1,19 @@
 MENUBUILD   := ../../../bin/build/config
 
 MENUCFLAGS  := -I/usr/include/ncurses -DCURSES_LOC="<ncurses.h>" -DLOCALE -Wall -Wmissing-prototypes -Wstrict-prototypes -O2 -fomit-frame-pointer
-
-ifeq ($(shell uname -s),Linux)
 MENULDFLAGS := -lncurses
+
+UNAME:=$(shell uname)
+ifeq ($(UNAME),Linux)
+  # do nothing
+else ifeq ($(UNAME),OpenBSD)
+  MENUCFLAGS += -I/usr/local/include
+  MENULDFLAGS += -L/usr/local/lib -lintl
 else
-MENULDFLAGS := -lncurses -lintl
+  MENULDFLAGS += -lintl
 endif
 
-HOSTCC      := gcc
+HOSTCC      := cc
 
 CONFBASE    := $(MENUBUILD)/lxdialog/menubox.o   \
                $(MENUBUILD)/lxdialog/yesno.o     \

--- a/tools/W806/wm_tool.c
+++ b/tools/W806/wm_tool.c
@@ -2957,6 +2957,8 @@ static void wm_tool_print_usage(const char *name)
                    "                          e.g: tty.usbserial0 tty.usbserial3 tty.usbserial7\r\n"
 #elif defined(__MINGW32__) || defined(__CYGWIN__)
                    "                          e.g: COM0 COM3 COM7\r\n"
+#elif defined(__OpenBSD__)
+                   "                          e.g: ttyU0 ttyU1 ttyU3\r\n"
 #elif defined(__linux__)
                    "                          e.g: ttyUSB0 ttyUSB3 ttyUSB7\r\n"
 #endif
@@ -4832,11 +4834,13 @@ static void wm_tool_show_local_com(void)
 #elif defined(__CYGWIN__)
     int num;
     char *comstr = "ttyS";
+#elif defined(__OpenBSD__)
+    char *comstr = "ttyU";
 #elif defined(__linux__)
     char *comstr = "ttyUSB";
 #endif
 
-#if defined(__APPLE__) || defined(__MACH__) || defined(__CYGWIN__) || defined(__linux__)
+#if defined(__APPLE__) || defined(__MACH__) || defined(__CYGWIN__) || defined(__linux__) || defined(__OpenBSD__)
 
     DIR *dir;
     struct dirent *file;


### PR DESCRIPTION
with generic toolchain (binutils-2.34 + gcc-9.4.0 + newlib-4.1.0), building democode and programming W806 MCU succeeded on OpenBSD.