### PR TITLE
Update wm_gpio_ex.h

### DIFF
--- a/include/driver/wm_gpio_ex.h
+++ b/include/driver/wm_gpio_ex.h
@@ -342,7 +342,7 @@
 												{													\
 													__AFIO_REMAP_SET_OPT2(__HANDLE__, __IOPOSITION__);	\
 												}													\
-												else if ((__HANDLE__ == GPIOA) && (__IOPOSITION__ == GPIO_PIN_08))	\
+												else if ((__HANDLE__ == GPIOA) && (__IOPOSITION__ == GPIO_PIN_8))	\
 												{													\
 													__AFIO_REMAP_SET_OPT3(__HANDLE__, __IOPOSITION__);	\
 												}													\


### PR DESCRIPTION
GPIO_PIN_08 定义无效，应改为GPIO_PIN_8